### PR TITLE
Add Firefox support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,19 @@
+# AniList client_id, from https://anilist.co/settings/developer
+#
+# Each AniList app registers exactly ONE Redirect URL, and each build ends its
+# OAuth flow at a different one — so each build needs its own app, and its own
+# client_id in its own copy of this file:
+#
+#   .env.development  npx plasmo dev                          (unpacked Chrome)
+#   .env.production   npx plasmo build                        (Chrome Web Store)
+#   .env.firefox      npx plasmo build --target=firefox-mv3   (Firefox / AMO)
+#
+# Chrome assigns the extension ID, and the unpacked and Web Store builds get
+# different ones — hence two separate Chrome apps. Firefox instead uses the ID
+# we declare ourselves (browser_specific_settings.gecko.id in package.json),
+# which is the same for a temporary install and the AMO build, so Firefox needs
+# only one app covering both. On a --target=firefox-* build .env.firefox
+# outranks .env.production, so the Firefox client_id wins there automatically.
+#
+# See the README for how to find each build's Redirect URL.
 PLASMO_PUBLIC_ANILIST_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -43,19 +43,39 @@ _A lightweight browser extension to manage your AniList anime and manga — with
 
 To run AniPortable locally:
 
-1. Clone the repository.
-2. Register your app with [AniList API](https://anilist.co/settings/developer) and obtain a `client_id`. Its **Redirect URL** must be `https://<extension-id>.chromiumapp.org/`, where `<extension-id>` is the ID Chrome assigns your locally-loaded unpacked extension (visible on `chrome://extensions` after your first load).
-3. Copy `.env.example` to `.env.development` (used by `npx plasmo dev`) and/or `.env.production` (used by `npx plasmo build`), and set `PLASMO_PUBLIC_ANILIST_CLIENT_ID` to your `client_id` in each. Both files are `.gitignore`d, so dev and production can safely use different AniList apps.
-4. Run `npm install` to install dependencies.
-5. Use `npx plasmo dev` (watch mode) or `npx plasmo build` (production build) to build locally with Plasmo.
+1. Clone the repository and run `npm install`.
+2. Register an app with the [AniList API](https://anilist.co/settings/developer), setting its **Redirect URL** to the one for your build (see below), and copy the `client_id`.
+3. Copy `.env.example` to the matching env file and set `PLASMO_PUBLIC_ANILIST_CLIENT_ID` to that `client_id`. Every `.env*` file except the example is `.gitignore`d.
+4. Build and load the extension (see [Builds](#builds)).
+
+AniList allows one Redirect URL per app, so each build needs its own app and `client_id`:
+
+| Build | Env file | Redirect URL |
+| --- | --- | --- |
+| Chrome, unpacked | `.env.development` | `https://<extension-id>.chromiumapp.org/` — ID is on `chrome://extensions` |
+| Chrome, Web Store | `.env.production` | Same, with the Web Store's (different) `<extension-id>` |
+| Firefox | `.env.firefox` | `https://2aa74d67c20b2df7e53c4ece72190bec8c657d82.extensions.allizom.org/` |
+
+Chrome assigns the extension ID, and gives the unpacked and Web Store builds different ones — hence two Chrome apps. Firefox instead uses the ID declared in `browser_specific_settings.gecko.id` and derives the Redirect URL as `https://<sha1(id)>.extensions.allizom.org/`, which is identical for a temporary install and the signed AMO build — so one Firefox app covers both.
+
+### Builds
+
+| Command | Output |
+| --- | --- |
+| `npx plasmo dev` | `build/chrome-mv3-dev` (watch/HMR) |
+| `npx plasmo build` | `build/chrome-mv3-prod` |
+| `npx plasmo build --target=firefox-mv3` | `build/firefox-mv3-prod` |
+| `npx plasmo package [--target=firefox-mv3]` | Zipped build, for store submission |
+
+Load the Chrome build with **Load unpacked** on `chrome://extensions`, or the Firefox build with **Load Temporary Add-on** on `about:debugging#/runtime/this-firefox`. On a `--target=firefox-*` build, `.env.firefox` outranks `.env.production`, so the Firefox `client_id` is picked up automatically.
 
 
 ## Permissions
 
-AniPortable requests the following Chrome Extension permissions:
+AniPortable requests the following browser extension permissions:
 
 - **storage** – Persists user settings and preferences locally.
-- **identity** – Used to authenticate users through AniList via `chrome.identity.launchWebAuthFlow`.
+- **identity** – Used to authenticate users through AniList via `identity.launchWebAuthFlow`.
 - **host_permissions** (`https://graphql.anilist.co/`) – Allows the background script to call the AniList GraphQL API directly.
 
 These are minimal and used solely to deliver core functionality securely and privately.

--- a/background.ts
+++ b/background.ts
@@ -180,12 +180,13 @@ restorePendingUpdates()
 // ============================================
 class Auth {
   // Set via .env.development (npx plasmo dev) / .env.production (npx plasmo build)
+  // / .env.firefox (build --target=firefox-mv3)
   static CLIENT_ID = process.env.PLASMO_PUBLIC_ANILIST_CLIENT_ID
 
   static async login() {
     if (!this.CLIENT_ID) {
       throw new Error(
-        "Missing PLASMO_PUBLIC_ANILIST_CLIENT_ID. Copy .env.example to .env.development (or .env.production) and set your AniList client_id."
+        "Missing PLASMO_PUBLIC_ANILIST_CLIENT_ID. Copy .env.example to .env.development (or .env.production, or .env.firefox) and set your AniList client_id."
       )
     }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,17 @@
     "background": {
       "service_worker": "background.ts",
       "type": "module"
+    },
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "aniportable@alexdeng901.github.io",
+        "strict_min_version": "140.0",
+        "data_collection_permissions": {
+          "required": [
+            "authenticationInfo"
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Builds the extension for Firefox alongside Chrome from the same codebase, via `plasmo build --target=firefox-mv3`.

Verified end-to-end in Firefox 152: login → list fetch → progress update → **confirmed persisted on anilist.co**. That last step matters because it exercises the debounced background flush surviving Firefox's event page being stopped.

## No extension logic changed

The functional diff is six lines of manifest. Two reasons it stayed that small:

- **`chrome.*` needs no rewrite.** Firefox aliases the namespace, and under MV3 it returns promises — so the background (promise style) and popup (callback style) both work untouched. No `webextension-polyfill`.
- **Plasmo rewrites the manifest per target.** It emits `background.scripts` for Firefox (which uses event pages, not service workers) and strips the `gecko` block from the Chrome build. One manifest in `package.json`, no per-browser forks.

## Changes

- **Declare `browser_specific_settings.gecko`.** Firefox derives the OAuth redirect URL as `sha1(gecko.id).extensions.allizom.org`, so the ID must be declared and stable. It's identical for a temporary install and the signed AMO build, so **one AniList app covers both** — unlike Chrome, which needs one per assigned extension ID.
- **`strict_min_version: 140`** — the later of two constraints: MV3 `chrome.*` promise support (128) and `data_collection_permissions` support (140). Below 140 the consent key is silently ignored. 140 is the current ESR; 128 EOL'd 2025-09-16, so the floor costs no real users.
- **Declare `data_collection_permissions: ["authenticationInfo"]`.** The OAuth token is transmitted to `graphql.anilist.co`; AMO has required disclosing this since 2025-11-03 and blocks submission without it.
- **Document the per-build AniList app / client_id split** (`.env.firefox`, which outranks `.env.production` on Firefox targets).

## Verification

- Both targets build; `tsc --noEmit` clean
- `web-ext lint`: **0 errors**
- Chrome build unchanged — `gecko` block correctly stripped

## Notes

- Remaining lint warnings are 3× bundled React/Apollo internals (`innerHTML`, `Function`) plus one `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` (Android got `data_collection_permissions` at 142, desktop at 140). The fix would be a `gecko_android` floor, but Plasmo drops that key — verified. Warning only; this is a desktop popup extension.
- Publishing still needs `plasmo package --target=firefox-mv3` and an AMO registration under `aniportable@alexdeng901.github.io`. That ID is load-bearing: the AniList redirect URL is its SHA-1, so changing it invalidates the registered app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
